### PR TITLE
Transaction color & sign in user retrieve

### DIFF
--- a/users/templates/users/retrieve.html
+++ b/users/templates/users/retrieve.html
@@ -94,12 +94,52 @@
     <tbody>
       {% for transaction in object.list_transaction|slice:":50" %}
       {% price_for sale=transaction user=object as price_for %}
-      <tr class="{% if transaction.amount > 0 %}success{% else %}danger{% endif %}">
+      <tr class="
+      {% if transaction|get_transaction_model == 'Sale' %}
+        danger
+      {% elif transaction|get_transaction_model == 'ExceptionnalMovement' %}
+        {% if transaction.is_credit %}
+          success
+        {% else %}
+          danger
+        {% endif %}
+      {% elif transaction|get_transaction_model == 'Transfert' %}
+        {% if transaction.sender.recipient == user %}
+          success
+        {% else %}
+          danger
+        {% endif %}
+      {% elif transaction|get_transaction_model == 'SharedEvent' %}
+        danger
+      {% else %}
+        success
+      {% endif %}
+      ">
         <td>{{ transaction.datetime }}</td>
         <td>
           {{ transaction.wording }}
         </td>
-        <td>{{ transaction.amount }}€</td>
+        <td>
+          {% if transaction|get_transaction_model == 'Sale' %}
+            -{{ transaction.amount }}€
+          {% elif transaction|get_transaction_model == 'ExceptionnalMovement' %}
+            {% if transaction.is_credit %}
+              {{ transaction.amount }}€
+            {% else %}
+              -{{ transaction.amount }}€
+            {% endif %}
+          {% elif transaction|get_transaction_model == 'Transfert' %}
+            {% if transaction.sender.recipient == user %}
+              {{ transaction.amount }}€
+            {% else %}
+              -{{ transaction.amount }}€
+            {% endif %}
+          {% elif transaction|get_transaction_model == 'SharedEvent' %}
+              -{{ transaction.amount }}€
+          {% else %}
+            {{ transaction.amount }}€
+          {% endif %}
+        </td>
         {% if group|has_group_perm:"retrieve_sale" %}
           <td><a href="
             {% if transaction|get_transaction_model == 'Sale' %}


### PR DESCRIPTION
# Transaction color & sign in user retrieve
## Version 4.4.3 (draft 4.5)
## See #25 

## Changes
* Transaction color are now the same as every transaction list (basically credit green and debit red) for user retrieve page.
* Transaction amount now show the sign (credit + and debit -) for user retrieve page.