### PR TITLE
Order users

### DIFF
--- a/users/forms.py
+++ b/users/forms.py
@@ -136,27 +136,25 @@ class UserSearchForm(forms.Form):
         		label="Utilisateur(s)",
                 max_length=255,
                 required=False,
-                widget=forms.TextInput(attrs={'class': 'form-control autocomplete_username',
+                widget=forms.TextInput(attrs={'class': 'form-control',
                                               'autocomplete': 'off',
         									  'autofocus': 'true',
-        									  'placeholder': "Nom d'utilisateur"}))
-    unactive = forms.BooleanField(
-        label='Désactivés seulement',
-        required=False
-    )
+        									  'placeholder': "Nom / Prénom / Surnom"}))
+    year = forms.ChoiceField(label='Année', required=False)
+    state = forms.ChoiceField(label='Etat', choices=(('all', 'Tous les utilisateurs'),
+                                                        ('True', 'Uniquement les activés'),
+                                                        ('False', 'Uniquement les desactivés')),
+                                            required=False)
 
     def __init__(self, **kwargs):
+        super(UserSearchForm, self).__init__(**kwargs)
+
         YEAR_CHOICES = [('all', 'Toutes')]
         for year in list_year():
             YEAR_CHOICES.append(
                 (year, year)
             )
-        super(UserSearchForm, self).__init__(**kwargs)
-        self.fields['year'] = forms.ChoiceField(
-            label='Année',
-            choices=YEAR_CHOICES,
-            required=False
-        )
+        self.fields['year'].choices = YEAR_CHOICES
 
 
 class UserQuickSearchForm(forms.Form):

--- a/users/templates/users/user_list.html
+++ b/users/templates/users/user_list.html
@@ -45,7 +45,9 @@
           </a></th>
         {% endfor %}
           <th>Etat</th>
-          <th>Détail</th>
+          {% if has_perm_retrieve_user %}
+            <th>Détail</th>
+          {% endif %}
       </tr>
     </thead>
     <tbody>
@@ -59,9 +61,11 @@
         <td>{{ user.year }}</td>
         <td>{{ user.balance }}€</td>
         <td>{% if user.is_active %}Activé{% else %}Désactivé{% endif %}</td>
-        <td>
-          <a href="{% url 'url_user_retrieve' group_name=group_name pk=user.pk %}">Détail</a>
-        </td>
+        {% if has_perm_retrieve_user %}
+          <td>
+            <a href="{% url 'url_user_retrieve' group_name=group_name pk=user.pk %}">Détail</a>
+          </td>
+        {% endif %}
       </tr>
       {% endfor %}
     </tbody>

--- a/users/templates/users/user_list.html
+++ b/users/templates/users/user_list.html
@@ -29,8 +29,8 @@
     <table class="table table-hover table-striped">
     <thead>
       <tr>
-          <th><a href="?sort=last_name">Nom</a></th>
-          <th><a href="?sort=first_name">Prénom</a></th>
+          <th><a href="?sort=username">Username</a></th>
+          <th><a href="?sort=last_name">Nom Prénom</a></th>
           <th><a href="?sort=surname">Bucque</a></th>
           <th><a href="?sort=family">Num's</a></th>
           <th><a href="?sort=campus">Tabagn's</a></th>
@@ -43,8 +43,8 @@
     <tbody>
       {% for user in user_list %}
       <tr class="{% if user.balance >= 0 %}success{% else %}danger{% endif %}">
-        <td>{{ user.last_name }}</td>
-        <td>{{ user.first_name }}</td>
+        <td>{{ user.username }}</td>
+        <td>{{ user.last_name }} {{ user.first_name }}</td>
         <td>{{ user.surname }}</td>
         <td>{{ user.family }}</td>
         <td>{{ user.campus }}</td>

--- a/users/templates/users/user_list.html
+++ b/users/templates/users/user_list.html
@@ -28,14 +28,22 @@
     {% if user_list %}
     <table class="table table-hover table-striped">
     <thead>
+
+
       <tr>
-          <th><a href="?sort=username">Username</a></th>
-          <th><a href="?sort=last_name">Nom Prénom</a></th>
-          <th><a href="?sort=surname">Bucque</a></th>
-          <th><a href="?sort=family">Num's</a></th>
-          <th><a href="?sort=campus">Tabagn's</a></th>
-          <th><a href="?sort=year">Prom's</a></th>
-          <th><a href="?sort=balance">Solde</a></th>
+        {% for name, description in list_header %}
+          <th><a href="?sort={{ name }}">{{ description }}
+            {% if sort and sort == name %}
+              {% if reverse %}
+                <i class="fa fa-sort-desc" aria-hidden="true"></i>
+              {% else %}
+                <i class="fa fa-sort-asc" aria-hidden="true"></i>
+              {% endif %}
+            {% else %}
+              <i class="fa fa-sort" aria-hidden="true"></i>
+            {% endif %}
+          </a></th>
+        {% endfor %}
           <th>Etat</th>
           <th>Détail</th>
       </tr>

--- a/users/views.py
+++ b/users/views.py
@@ -332,29 +332,24 @@ class UserListView(GroupPermissionMixin, FormView, GroupLateralMenuFormMixin):
     form_class = UserSearchForm
 
     search = None
-    unactive = None
     year = None
-    headers = {'first_name':'asc',
+    state = None
+    headers = {'username':'asc',
          'last_name':'asc',
          'surname':'asc',
          'family':'asc',
          'campus':'asc',
          'year':'asc',
-         'balance':'asc',}
+         'balance':'asc'}
     sort = None
 
-    def get(self, request, *args, **kwargs):
-        """
-        Used to pass search through workboard.
-        """
+    def get_context_data(self, **kwargs):
+
         try:
-            self.sort = request.GET['sort']
-            self.search = request.GET['search']
+            self.sort = self.request.GET['sort']
         except KeyError:
             pass
-        return super(UserListView, self).get(request, *args, **kwargs)
 
-    def get_context_data(self, **kwargs):
         context = super(UserListView, self).get_context_data(**kwargs)
         context['group'] = self.group
         if self.sort is not None:
@@ -372,7 +367,6 @@ class UserListView(GroupPermissionMixin, FormView, GroupLateralMenuFormMixin):
         return context
 
     def form_query(self, query):
-
         if self.search:
             query = query.filter(
                 Q(last_name__icontains=self.search)
@@ -381,22 +375,22 @@ class UserListView(GroupPermissionMixin, FormView, GroupLateralMenuFormMixin):
                 | Q(username__icontains=self.search)
             )
 
-        if self.unactive:
-            query = query.filter(
-                is_active=False)
-
         if self.year and self.year != 'all':
             query = query.filter(
                 year=self.year)
 
+        if self.state and self.state != 'all':
+            query = query.filter(
+                is_active=self.state)
+                
         return query
 
     def form_valid(self, form):
         if form.cleaned_data['search']:
             self.search = form.cleaned_data['search']
 
-        if form.cleaned_data['unactive']:
-            self.unactive = form.cleaned_data['unactive']
+        if form.cleaned_data['state']:
+            self.state = form.cleaned_data['state']
 
         if form.cleaned_data['year']:
             self.year = form.cleaned_data['year']

--- a/users/views.py
+++ b/users/views.py
@@ -344,16 +344,22 @@ class UserListView(GroupPermissionMixin, FormView, GroupLateralMenuFormMixin):
     sort = None
 
     def get_context_data(self, **kwargs):
+        context = super(UserListView, self).get_context_data(**kwargs)
+
+        ## Header List
+        context['list_header'] = [["username", "Username"], ["last_name", "Nom Prénom"], ["surname", "Bucque"], ["family", "Fam's"], ["campus", "Tabagn's"], ["year", "Prom's"], ["balance", "Solde"]]
+
 
         try:
             self.sort = self.request.GET['sort']
         except KeyError:
             pass
 
-        context = super(UserListView, self).get_context_data(**kwargs)
         context['group'] = self.group
         if self.sort is not None:
+          context['sort'] = self.sort
           if self.headers[self.sort] == "des":
+            context['reverse'] = True
             context['user_list'] = self.form_query(
                 User.objects.all().exclude(groups=1).order_by(self.sort).reverse())
             self.headers[self.sort] = "asc"
@@ -364,6 +370,9 @@ class UserListView(GroupPermissionMixin, FormView, GroupLateralMenuFormMixin):
         else:
             context['user_list'] = self.form_query(
               User.objects.all().exclude(groups=1))
+
+
+
         return context
 
     def form_query(self, query):
@@ -382,7 +391,7 @@ class UserListView(GroupPermissionMixin, FormView, GroupLateralMenuFormMixin):
         if self.state and self.state != 'all':
             query = query.filter(
                 is_active=self.state)
-                
+
         return query
 
     def form_valid(self, form):

--- a/users/views.py
+++ b/users/views.py
@@ -371,7 +371,9 @@ class UserListView(GroupPermissionMixin, FormView, GroupLateralMenuFormMixin):
             context['user_list'] = self.form_query(
               User.objects.all().exclude(groups=1))
 
-
+        # Permission Retrieveuser
+        if Permission.objects.get(codename='retrieve_user') in self.group.permissions.all():
+            context['has_perm_retrieve_user'] = True
 
         return context
 


### PR DESCRIPTION
**Related issue : #8 (Rex_Birse)**

# Changes : 
* Add state field for searching all users, or only activated or unactivated. Remove old field "unactivate".
* Modifications in template : 
  - Last name and First name column regrouped
  - New column with usernames
  - Use fa icons to order the list of users
  - Remove "Details" column if the user group doesn't have the "retrieve user" permission.
