### PR TITLE
Fix : Shops - JS to buy same products

### DIFF
--- a/modules/forms.py
+++ b/modules/forms.py
@@ -31,11 +31,7 @@ class SelfSaleShopModule(forms.Form):
                         widget=forms.NumberInput(
                             attrs={'data_category_pk': category.pk,
                                    'data_price': category_product.get_price(),
-                                   'class': 'form-control',
-                                   'pk': (
-                                       str(category_product.product.pk)
-                                       + '-'
-                                       + str(category.pk)),
+                                   'class': 'form-control buyable_product',
 									'min': 0}),
                         initial=0,
                         required=False,

--- a/modules/templates/modules/js/navigation_sales.html
+++ b/modules/templates/modules/js/navigation_sales.html
@@ -47,49 +47,6 @@ $(document).keydown(function(e) {
     }
   })
 
-   // Function to update the balance of the user.
-   // Then calculate the futur balance of the user
-   function update_initial(client_id) {
-     if (client_id == '') {
-       // No client ID, set default
-       // Don't need to call ajax
-       $("#initial").text(Number(0).toFixed(2))
-     } else {
-       // Get balance for the client
-       $.ajax({
-           url: "/ajax/balance_from_username/",
-           dataType: "json",
-           data: {
-               username: client_id
-           },
-           success: function( data ) {
-               $('#initial').text(data);
-               total();
-           },
-           error: function(jqXHR, textStatus, errorThrown) {
-                // On error, set everything to default
-               $('#id_client').val('');
-               $('#initial').text(Number(0).toFixed(2));
-               total();
-           }
-       })
-     }
-   }
-
-     // On blur, must recheck ...
-     // Because an autocomplete is not a select, one can send anything !
-    $("#id_client").blur(function() {
-      update_initial($(this).val());
-    });
-
-   // On select autocomplete option (works for enter too)
-   // Wrapped into $(function() { ... }) to force execution when page is fully loaded.
-   // Else, autocomplete (defined by class and js import) is executed after that.
-   $(function() {
-     $("#id_client").autocomplete('option', 'select', function(e, ui) {
-       update_initial(ui.item.value);
-     });
-   });
 {% endif %}
 
 // Navigation script

--- a/modules/templates/modules/js/update_total_sales.html
+++ b/modules/templates/modules/js/update_total_sales.html
@@ -1,9 +1,11 @@
 {% block content %}
 <script>
-$("input[id^='id_']").change(function() {
-  var pk = $(this).attr('pk');
+
+// In case a user select a product
+$(".buyable_product").change(function() {
+  var name = $(this).attr('name');
   var usual_price = $(this).attr('data_price');
-  $('#total_' + pk).text((Number(usual_price) * Number($(this).val())).toFixed(2));
+  $('#total_' + name).text((Number(usual_price) * Number($(this).val())).toFixed(2));
   total();
 })
 
@@ -11,26 +13,36 @@ $("input[id^='id_']").change(function() {
 function total() {
   var total = 0
   $('#invoice').empty();
-  $("input[id^='id_']").each(function() {
-    var pk = $(this).attr('pk');
+
+  // For each product of the shop
+  $(".buyable_product").each(function() {
+    // Get the name of the product
     var product = $("label[for='" + $(this).attr('id') + "']")
       .text()
-      .substring(
-        0,
-        $("label[for='" + $(this).attr('id') + "']").text().length - 1
-      );
-    total += Number($('#total_' + pk).text());
+      .substring(0, -1);
+
+    // Get the value
+    value = Number($(this).val());
+
+    // Add to total price
+    total += $(this).attr('data_price') * value;
+
+    // Add in the list of selected products
     if ($(this).val() > 0) {
-      $('#invoice').append('<li>' + product + ' x' + $(this).val() + '</li>');
+      $('#invoice').append('<li>' + product + ' x' + value + '</li>');
     }
-  })
-  $('#total').text(total.toFixed(2));
-  $('#result').text(
-    (Number($('#initial').text()) - total.toFixed(2)).toFixed(2)
-  );
-  if (Number($('#result').text()) < 0) {
+  });
+
+  // Update results
+  total = total.toFixed(2);
+  $('#total').text(total);
+  result = (Number($('#initial').text()) - total).toFixed(2);
+  $('#result').text(result);
+
+  // Change result coloration
+  if (result < 0) {
     $('#result_line').attr('class', 'col-md-4 bg-danger');
-  } else if (Number($('#result').text()) > 0) {
+  } else if (result > 0) {
     $('#result_line').attr('class', 'col-md-4 bg-success');
   } else {
     $('#result_line').attr('class', 'col-md-4');
@@ -49,9 +61,58 @@ $(document).ready(function() {
   {% endif %}
   // Update product inputs
   // Type number for products only (id_client: type text)
-  $("input[id^='id_']:input[type='number']").each(function() {
+  $(".buyable_product").each(function() {
     $(this).trigger('change');
   });
 });
+
+
+{% if type == "operator_sale" %}
+
+   // Function to update the balance of the user.
+   // Then calculate the futur balance of the user
+   function update_initial(client_id) {
+     if (client_id == '') {
+       // No client ID, set default
+       // Don't need to call ajax
+       $("#initial").text(Number(0).toFixed(2))
+     } else {
+       // Get balance for the client
+       $.ajax({
+           url: "/ajax/balance_from_username/",
+           dataType: "json",
+           data: {
+               username: client_id
+           },
+           success: function( data ) {
+               $('#initial').text(data);
+               total();
+           },
+           error: function(jqXHR, textStatus, errorThrown) {
+                // On error, set everything to default
+               $('#id_client').val('');
+               $('#initial').text(Number(0).toFixed(2));
+               total();
+           }
+       })
+     }
+   }
+
+     // On blur, must recheck ...
+     // Because an autocomplete is not a select, one can send anything !
+    $("#id_client").blur(function() {
+      update_initial($(this).val());
+    });
+
+   // On select autocomplete option (works for enter too)
+   // Wrapped into $(function() { ... }) to force execution when page is fully loaded.
+   // Else, autocomplete (defined by class and js import) is executed after that.
+   $(function() {
+     $("#id_client").autocomplete('option', 'select', function(e, ui) {
+       update_initial(ui.item.value);
+     });
+   });
+{% endif %}
+
 </script>
 {% endblock %}

--- a/modules/templates/modules/shop_module_sale_interface.html
+++ b/modules/templates/modules/shop_module_sale_interface.html
@@ -103,7 +103,7 @@
                       <td>{{ field.errors }}{{ field.label_tag }}</td>
                       <td>{{ field }}</td>
                       <td>{{ field.field.widget.attrs.data_price|unlocalize }}€</td>
-                      <td><span id="total_{{ field.field.widget.attrs.pk }}">0.00</span>€</td>
+                      <td><span id="total_{{ field.html_name }}">0.00</span>€</td>
                     </tr>
                     {% endif %}
                   {% endfor %}


### PR DESCRIPTION
Related issue : #1  (REX Birse)

**Fix :**
In JS, the 'pk' attribute was similar in every same product. 
JS now use the 'name' attribute, which is different for each product ( back end uses this field).

The old 'pk' attributs, no longer relevant, is removed.

**I also made some minor modifications for a better understanding and improvement :**
- "update_initial" was moved in update_total_sales js. 
- i created a new class "buyable_item", for better understanding. ("input[id^='id_']" was matching with "id_client", which caused some bugs. And I believe "buyable_item" is better than "input[id^='id_']:input[type='number']" ).