### PR TITLE
fix rechargings list & add indication limit

### DIFF
--- a/finances/models.py
+++ b/finances/models.py
@@ -679,6 +679,20 @@ class SharedEvent(models.Model):
             total += e.weights_participation
         return total
 
+    def total_number_registrants(self):
+        total = 0
+        for e in self.weightsuser_set.all():
+            if e.weights_registeration > 0:
+                total += 1
+        return total
+
+    def total_number_participants(self):
+        total = 0
+        for e in self.weightsuser_set.all():
+            if e.weights_participation > 0:
+                total += 1
+        return total
+
     class Meta:
         """
         Define Permissions for SharedEvent.

--- a/finances/models.py
+++ b/finances/models.py
@@ -679,20 +679,6 @@ class SharedEvent(models.Model):
             total += e.weights_participation
         return total
 
-    def total_number_registrants(self):
-        total = 0
-        for e in self.weightsuser_set.all():
-            if e.weights_registeration > 0:
-                total += 1
-        return total
-
-    def total_number_participants(self):
-        total = 0
-        for e in self.weightsuser_set.all():
-            if e.weights_participation > 0:
-                total += 1
-        return total
-
     class Meta:
         """
         Define Permissions for SharedEvent.

--- a/finances/templates/finances/recharging_list.html
+++ b/finances/templates/finances/recharging_list.html
@@ -18,6 +18,7 @@
               <div class="col-sm-10 col-sm-offset-2">
                 <button type="submit" class="btn btn-primary">Recherche</button>
                 <a class="btn btn-warning" href="">Remise à zéro</a>
+                <span style="opacity: 0.54; margin-left: 5px;">Les 1000 premiers résultats sont affichés</span>
               </div>
             </div>
           </form>

--- a/finances/templates/finances/sharedevent_list.html
+++ b/finances/templates/finances/sharedevent_list.html
@@ -35,14 +35,16 @@
           <th>Préinscrits / Participants</th>
           <th>Status</th>
           <th>Remarque</th>
+          {% if user == sharedevent.manager %}
           <th>Gestion</th>
+          {% endif %}
         </tr>
         {% for sharedevent in shared_events %}
         <tr>
           <td>{{ sharedevent.date|date:"d/m/Y" }}</td>
           <td>{{ sharedevent.description }}</td>
           <td>{{ sharedevent.manager }}</td>
-          <td>{{ sharedevent.total_weights_registrants }}/{{ sharedevent.total_weights_participants }}</td>
+          <td>{{ sharedevent.total_nb_registrants }}/{{ sharedevent.total_nb_participants }}</td>
           {% if sharedevent.done %}
             <td>Terminé</td>
             <td>Participation : {{ sharedevent.weight_of_user }}</td>

--- a/finances/templates/finances/sharedevent_list.html
+++ b/finances/templates/finances/sharedevent_list.html
@@ -44,7 +44,7 @@
           <td>{{ sharedevent.date|date:"d/m/Y" }}</td>
           <td>{{ sharedevent.description }}</td>
           <td>{{ sharedevent.manager }}</td>
-          <td>{{ sharedevent.total_nb_registrants }}/{{ sharedevent.total_nb_participants }}</td>
+-          <td>{{ sharedevent.total_weights_registrants }}/{{ sharedevent.total_weights_participants }}</td>
           {% if sharedevent.done %}
             <td>Terminé</td>
             <td>Participation : {{ sharedevent.weight_of_user }}</td>

--- a/finances/views.py
+++ b/finances/views.py
@@ -500,7 +500,7 @@ class RechargingList(GroupPermissionMixin, FormView,
         context['recharging_list'] = Recharging.objects.all().order_by('-datetime')
 
         context['recharging_list'] = self.form_query(
-            context['recharging_list'])[:100]
+            context['recharging_list'])[:1000]
 
         context['info'] = self.info(context['recharging_list'])
         return context
@@ -515,7 +515,8 @@ class RechargingList(GroupPermissionMixin, FormView,
         info = {
             'cash': {
                 'total': 0,
-                'nb': 0
+                'nb': 0,
+                'ids': Cash.objects.none()
             },
             'cheque': {
                 'total': 0,
@@ -542,18 +543,19 @@ class RechargingList(GroupPermissionMixin, FormView,
             if r.payment_solution.get_type() == 'cash':
                 info['cash']['total'] += r.payment_solution.amount
                 info['cash']['nb'] += 1
+                info['cash']['ids'] |= Cash.objects.filter(pk=r.payment_solution.cash.pk)
             if r.payment_solution.get_type() == 'cheque':
                 info['cheque']['total'] += r.payment_solution.amount
                 info['cheque']['nb'] += 1
-                info['cheque']['ids'] |= [r.payment_solution.cheque]
+                info['cheque']['ids'] |= Cheque.objects.filter(pk=r.payment_solution.cheque.pk)
             if r.payment_solution.get_type() == 'lydiafacetoface':
                 info['lydia_face2face']['total'] += r.payment_solution.amount
                 info['lydia_face2face']['nb'] += 1
-                info['lydia_face2face']['ids'] |= [r.payment_solution.lydiafacetoface]
+                info['lydia_face2face']['ids'] |= LydiaFaceToFace.objects.filter(pk=r.payment_solution.lydiafacetoface.pk)
             if r.payment_solution.get_type() == 'lydiaonline':
                 info['lydia_online']['total'] += r.payment_solution.amount
                 info['lydia_online']['nb'] += 1
-                info['lydia_online']['ids'] |= [r.payment_solution.lydiaonline]
+                info['lydia_online']['ids'] |= LydiaOnline.objects.filter(pk=r.payment_solution.lydiaonline.pk)
             info['total']['total'] += r.payment_solution.amount
             info['total']['nb'] += 1
         return info


### PR DESCRIPTION
# Fix Recharging List

## Changes
* Extend the limit of rechargings displayed in the page recharging list from 100 to 1000.
* Add an indication of this limit in the form.

## Fixes
* Fix a bug induced by Django 2.0 where `|=` cannot be applied to lists but only querysets (was previously converted to `+=` when applied to lists).