### PR TITLE
Feature: Add Inventory with entries

### DIFF
--- a/stocks/forms.py
+++ b/stocks/forms.py
@@ -24,7 +24,7 @@ class StockEntryProductForm(forms.Form):
         widget=forms.NumberInput(
             attrs={'class': 'form-control centered_input quantity',
                     'placeholder': 'Quantité',
-                    'min':1, 'required':'required'}
+                    'min': 1, 'required':'required'}
         )
     )
     unit_quantity = forms.ChoiceField(
@@ -41,7 +41,7 @@ class StockEntryProductForm(forms.Form):
         widget=forms.NumberInput(
             attrs={'class': 'form-control centered_input amount',
                     'placeholder': 'Montant',
-                    'min':0, 'required':'required'}
+                    'min': 0, 'required':'required'}
         ))
     unit_amount = forms.ChoiceField(
         label='Unité montant',
@@ -56,15 +56,15 @@ class StockEntryProductForm(forms.Form):
         widget=forms.NumberInput(
             attrs={'class': 'form-control centered_input quantity',
                     'placeholder': 'Stocks rest.',
-                    'min':1}
+                    'min': 0}
         ),
     )
     unit_inventory = forms.ChoiceField(
-        label='Unité montant',
-        choices=([('UNIT', '€ / unité'), ('PACKAGE', '€ / lot'), ('L', '€ / L'), ('KG', '€ / kg')]),
+        label='Unité quantité',
+        choices=([('UNIT', 'produits'), ('CL', 'cl'), ('L', 'L'), ('G', 'g'), ('KG', 'kg')]),
         required=False,
         widget=forms.Select(
-            attrs={'class': 'form-control selectpicker unit_amount'})
+            attrs={'class': 'form-control selectpicker unit_quantity'})
     )
 
     def clean(self):

--- a/stocks/forms.py
+++ b/stocks/forms.py
@@ -18,8 +18,6 @@ class StockEntryProductForm(forms.Form):
                                                     attrs={'class': 'form-control selectpicker',
                                                     'data-live-search': 'True', 'required':'required'})
                                                     )
-
-
     quantity = forms.IntegerField(
         label='En vente',
         required=False,
@@ -32,9 +30,9 @@ class StockEntryProductForm(forms.Form):
     unit_quantity = forms.ChoiceField(
         label='Unité quantité',
         choices=([('UNIT', 'produits'), ('CL', 'cl'), ('L', 'L'), ('G', 'g'), ('KG', 'kg')]),
+        required=False,
         widget=forms.Select(
-            attrs={'class': 'form-control selectpicker unit_quantity', 'required': 'required'}),
-        required=False
+            attrs={'class': 'form-control selectpicker unit_quantity', 'required': 'required'})
     )
     amount = forms.DecimalField(
         label='Prix (€)',
@@ -48,14 +46,53 @@ class StockEntryProductForm(forms.Form):
     unit_amount = forms.ChoiceField(
         label='Unité montant',
         choices=([('UNIT', '€ / unité'), ('PACKAGE', '€ / lot'), ('L', '€ / L'), ('KG', '€ / kg')]),
+        required=False,
         widget=forms.Select(
-            attrs={'class': 'form-control selectpicker unit_amount', 'required':'required'}),
-        required=False
+            attrs={'class': 'form-control selectpicker unit_amount', 'required':'required'})
+    )
+    inventory_quantity = forms.IntegerField(
+        label='Stocks restant',
+        required=False,
+        widget=forms.NumberInput(
+            attrs={'class': 'form-control centered_input quantity',
+                    'placeholder': 'Stocks rest.',
+                    'min':1}
+        ),
+    )
+    unit_inventory = forms.ChoiceField(
+        label='Unité montant',
+        choices=([('UNIT', '€ / unité'), ('PACKAGE', '€ / lot'), ('L', '€ / L'), ('KG', '€ / kg')]),
+        required=False,
+        widget=forms.Select(
+            attrs={'class': 'form-control selectpicker unit_amount'})
     )
 
     def clean(self):
         cleaned_data = super(StockEntryProductForm, self).clean()
         # Validation direct in html
+
+
+class BaseInventoryProductFormSet(BaseFormSet):
+    def clean(self):
+        """
+        Check that there is max one inventory for each product
+        """
+        if any(self.errors):
+            # Don't bother validating the formset unless each form is valid on its own
+            return
+
+        products = []
+        for form in self.forms:
+            product = form.cleaned_data['product'].split('/')[0]
+
+            if product in products:
+                raise forms.ValidationError("Impossible de définir deux produits identiques dans le même inventaire")
+            products.append(product)
+
+
+class AdditionnalDataStockEntryForm(forms.Form):
+    isAddingInventory = forms.ChoiceField(label='Faire également un inventaire des stocks',
+                            choices=([('with', 'Avec'), ('without', 'Sans')]))
 
 
 class StockEntryListDateForm(forms.Form):
@@ -80,9 +117,11 @@ class StockEntryListDateForm(forms.Form):
         widget=forms.DateInput(attrs={'class': 'datepicker'}),
         required=False)
 
+
 class AdditionnalDataInventoryForm(forms.Form):
     type = forms.ChoiceField(label='Type d\'Inventaire',
                             choices=([('partial', 'Partiel'), ('full', 'Complet')]))
+
 
 class InventoryProductForm(forms.Form):
     def __init__(self, *args, **kwargs):
@@ -119,6 +158,7 @@ class InventoryProductForm(forms.Form):
     def clean(self):
         cleaned_data = super(InventoryProductForm, self).clean()
         # Validation direct in html
+
 
 class BaseInventoryProductFormSet(BaseFormSet):
     def clean(self):

--- a/stocks/templates/stocks/shop_inventory_create.html
+++ b/stocks/templates/stocks/shop_inventory_create.html
@@ -43,7 +43,7 @@ $('.category_formset').formset({
   addText: 'Nouveau produit',
   deleteText: 'Supprimer',
   addCssClass: 'add-row btn btn-success btn-sm',
-  deleteCssClass: 'delete-row',
+  deleteCssClass: 'delete-row btn btn-warning btn-sm',
   added: function(row) {
     $(row).find('.selectpicker').each(function() {
       $(this).selectpicker()

--- a/stocks/templates/stocks/shop_inventory_create.html
+++ b/stocks/templates/stocks/shop_inventory_create.html
@@ -14,7 +14,7 @@
   <div class="panel-body">
     <form method="post">
       {% csrf_token %}
-      {{ additionnal_data_form|bootstrap }}
+      {{ additionnal_data_form|bootstrap_horizontal }}
       <h3> Liste des produits :</h3>
       {{ inventory_formset.management_form }}
       {{ inventory_formset.non_form_errors }}

--- a/stocks/templates/stocks/shop_stock_entry_create.html
+++ b/stocks/templates/stocks/shop_stock_entry_create.html
@@ -48,7 +48,7 @@ $('.category_formset').formset({
   addText: 'Nouveau produit',
   deleteText: 'Supprimer',
   addCssClass: 'add-row btn btn-success btn-sm',
-  deleteCssClass: 'delete-row',
+  deleteCssClass: 'delete-row btn btn-warning btn-sm',
   added: function(row) {
     $(row).find('.selectpicker').each(function() {
       $(this).selectpicker()

--- a/stocks/templates/stocks/shop_stock_entry_create.html
+++ b/stocks/templates/stocks/shop_stock_entry_create.html
@@ -9,15 +9,17 @@
 
 <div class="panel panel-default">
   <div class="panel-heading">
-    Ajout de produits au stock du magasin {{ shop }}
+    Entrée de stock au magasin {{ shop }}
   </div>
   <div class="panel-body">
     <form method="post">
       {% csrf_token %}
+	  {{ add_inventory_form|bootstrap }}
+      <h3>Ajouter les produits :</h3>
       {{ stockentry_form.management_form }}
       {% for form in stockentry_form %}
         <div class="category_formset row" style="margin-bottom: 15px">
-          <div class="col-md-5">
+            <div class="col-md-3">
               {{ form.product }}
             </div>
             <div class="col-md-3 quantity_unit">
@@ -33,6 +35,14 @@
                 {{ form.amount }}
                 <span class="input-group-btn">
                   {{ form.unit_amount }}
+                </span>
+              </div>
+            </div>
+            <div class="col-md-2 product_inventory">
+              <div class="input-group">
+                {{ form.inventory_quantity }}
+                <span class="input-group-btn">
+                  {{ form.unit_inventory }}
                 </span>
               </div>
             </div>
@@ -183,6 +193,20 @@ function update_units(e) {
     $(this).closest('.row').find('.unit_amount').selectpicker('val', '')
   }
 }
+
+function update_inventory_form() {
+    var val = $('#id_isAddingInventory').find(':selected').val();
+    if (val == 'with') {
+        $('.product_inventory').show();
+    }
+    else if (val == 'without') {
+        $('.product_inventory').hide();
+    };
+};
+
+$(update_inventory_form);
+$('#id_isAddingInventory').change(update_inventory_form);
+
 </script>
 <style>
   .add-row {

--- a/stocks/templates/stocks/shop_stock_entry_create.html
+++ b/stocks/templates/stocks/shop_stock_entry_create.html
@@ -46,6 +46,7 @@
                 </span>
               </div>
             </div>
+                {% if form.instance.pk %}{{ form.DELETE }}{% endif %}
         </div>
       {% endfor %}
       <button class="btn btn-success" type="submit">Valider</button>
@@ -57,8 +58,8 @@
 $('.category_formset').formset({
   addText: 'Nouveau produit',
   deleteText: 'Supprimer',
-  addCssClass: 'add-row btn btn-success btn-sm',
-  deleteCssClass: 'delete-row btn btn-warning btn-sm',
+  addCssClass: 'btn btn-info',
+  // deleteCssClass: 'btn btn-warning', NOT WORKING. Workaround -> adding_btn_class_to_delete()
   added: function(row) {
     $(row).find('.selectpicker').each(function() {
       $(this).selectpicker()
@@ -68,6 +69,7 @@ $('.category_formset').formset({
     })
     $(row).find('.selectpicker').trigger('change'),
     $(update_inventory_form);
+    $(adding_btn_class_to_delete);
   }
 })
 $("[id$='product']").change(function(e) {
@@ -204,32 +206,32 @@ function update_inventory_form() {
         $('.product_inventory').hide();
     };
 };
+function adding_btn_class_to_delete() {
+    var delete_button = $('.delete-row'); // Default class of delete link
+    delete_button.addClass('btn btn-warning');
+};
 
 $(update_inventory_form);
+$(adding_btn_class_to_delete);
 $('#id_isAddingInventory').change(update_inventory_form);
+
 
 </script>
 <style>
-  .add-row {
-    margin: 15px;
-  }
-  .centered_input {
+    .centered_input {
     text-align: center;
-  }
-  .delete_row {
-    margin-top: 10px;
-  }
-  .unit_quantity {
+    }
+    .unit_quantity {
     width: 60px;
-  }
-  .unit_amount {
-    width: 100px;
-  }
-  .input-group-btn > div > button {
+    }
+    .unit_amount {
+    width: 60px;
+    }
+    .input-group-btn > div > button {
     background-color: #eee;
-  }
-  .input-group .bootstrap-select.form-control {
+    }
+    .input-group .bootstrap-select.form-control {
     z-index: inherit;
-  }
+    }
 </style>
 {% endblock %}

--- a/stocks/templates/stocks/shop_stock_entry_create.html
+++ b/stocks/templates/stocks/shop_stock_entry_create.html
@@ -66,7 +66,8 @@ $('.category_formset').formset({
     $("[id$='product']").change(function(e) {
       update_units.bind(this)(e)
     })
-    $(row).find('.selectpicker').trigger('change')
+    $(row).find('.selectpicker').trigger('change'),
+    $(update_inventory_form);
   }
 })
 $("[id$='product']").change(function(e) {


### PR DESCRIPTION
The idea is that when you add a product, you should be aware of the quantity left of it, and be able to make an inventory of it. That's what this PR is for.

Related issue : #42 

# Change : 
- Add possibility to make an inventory while making an entry (see a7273fd).

# Fix
- transform the previous normal delete link into a button-warning with bootstrap classes (see workaround with 5ba85d8)