### PR TITLE
[Finances] Possibility to change the ownership of a shared event

### DIFF
--- a/finances/forms.py
+++ b/finances/forms.py
@@ -317,6 +317,12 @@ class SharedEventFinishForm(forms.Form):
 class SharedEventUpdateForm(forms.Form):
     price = forms.DecimalField(label='Prix total (€)', decimal_places=2, max_digits=9, min_value=0, required=False)
     bills = forms.CharField(label='Factures liées', required=False)
+    manager = forms.CharField(label='Gestionnaire', required=False,
+                                widget=forms.TextInput(
+                                attrs={'class':
+                                       'autocomplete_username'}),
+                                validators=[
+                                autocomplete_username_validator])
     allow_self_registeration = forms.BooleanField(label='Autoriser la préinscription', required=False)
 
 


### PR DESCRIPTION
## Possibility to change the ownership of a shared event

- On the shared event page, the event's manager can remove his ownership of the event and give it to another user, that user must belong to a group that has permissions to manage shared event.
- Fixes #70