### PR TITLE
[Modules] Possibility to change category order for each module

### DIFF
--- a/borgia/modules/forms.py
+++ b/borgia/modules/forms.py
@@ -120,6 +120,13 @@ class ModuleCategoryCreateNameForm(forms.Form):
         label='Nom',
         max_length=254
     )
+    order = forms.IntegerField(
+        label='Ordre',
+        min_value=0,
+        validators=[MinValueValidator(0,'Cette valeur doit être positive')],
+        required=True,
+        help_text="L'ordre des catégories commence à partir de 0 !"
+    )
 
 
 class ShopModuleConfigForm(forms.Form):

--- a/borgia/modules/mixins.py
+++ b/borgia/modules/mixins.py
@@ -68,6 +68,7 @@ class ShopModuleMixin(ShopMixin):
         context = super().get_context_data(**kwargs)
         context['module_class'] = self.module_class
         context['module'] = self.module
+        context['categories'] = self.module.categories.all().order_by('order')
         return context
 
     def handle_unexpected_module_class(self):

--- a/borgia/modules/models.py
+++ b/borgia/modules/models.py
@@ -25,6 +25,7 @@ class Category(models.Model):
     module_id = models.PositiveIntegerField()
     module = GenericForeignKey('content_type', 'module_id')
     products = models.ManyToManyField(Product, through='CategoryProduct')
+    order = models.PositiveIntegerField(default=0)
 
     class Meta:
         """

--- a/borgia/modules/templates/modules/shop_module_config.html
+++ b/borgia/modules/templates/modules/shop_module_config.html
@@ -37,11 +37,11 @@
       <a href="{% url 'url_shop_module_category_create' shop_pk=shop.pk module_class=module_class %}"role="button" class="btn btn-xs btn-success" style='margin-left: 10px'>Ajouter une catégorie</a>
   </div>
   <div class="panel-body">
-    {% if module.categories.all.count == 0 %}
+    {% if categories.count == 0 %}
       <p style="opacity: 0.54;">Rien n'est en vente actuellement dans ce module.</p>
     {% endif %}
     <div class="row">
-      {% for category in module.categories.all %}
+      {% for category in categories %}
       <div class="col-md-4">
         <div class="panel panel-default">
           <div class="panel-heading">


### PR DESCRIPTION
Fixes issue #105 

- Adds a positive integer parameter "order" in the Category model
- Possibility to switch and shift category orders
- Categories (tabs) are displayed according to their respective orders