### PR TITLE
Update first user groups

### DIFF
--- a/borgia/users/fixtures/initial.json
+++ b/borgia/users/fixtures/initial.json
@@ -171,7 +171,7 @@
         "campus": null,
         "phone": null,
         "jwt_iat": "2016-02-15T13:32:56.781Z",
-        "groups": [1],
+        "groups": [1, 3],
         "user_permissions": []
         }
     }


### PR DESCRIPTION
Le premier utilisateur inscrit ne correspond plus à ce qui est indiqué dans la procédure d'installation.
En particulier, son groupe est "utilisateur simple" et ne permet donc pas de définir les paramètres de Borgia.

Je propose d'ajouter le groupe Président à cet utilisateur qui doit être temporaire et supprimé une fois que l'installation est terminée